### PR TITLE
Added extensionKind to package.json to allow users to use the extension remotely

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
       }
     ]
   },
+  "extensionKind": [
+    "ui"
+  ],
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "esbuild-base": "rimraf out && copyfiles -au 1 ./src/login/* out/ && esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",


### PR DESCRIPTION
Based on research from @mattschlosser, the `extensionKind` property needs to be included in order to run the extension in remote environments, like Remote Containers, WSL, etc.

My Twitch Themer extension already includes this and that's why VSC doesn't have a problem loading it. However, it repeatedly asks to reload this auth extension because it is trying to run it remotely.

Merge this garbage and stop making me fix your code. 

![image](https://github.com/clarkio/vscode-authentication-twitch/assets/1228996/7b704a33-30f3-43ae-a2bc-6f5beb0dfcda)

